### PR TITLE
profile: remove deref u64 and implement display trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,11 @@ pub use url;
 /// # Params
 /// - `profile_id` is aoe4world the ID of the player whose games should be searched.
 pub async fn profile(profile_id: u64) -> Result<Profile> {
-    reqwest::get(format!(
-        "https://aoe4world.com/api/v0/players/{}",
-        profile_id
-    ))
-    .await?
-    .json()
-    .await
-    .map_err(anyhow::Error::from)
+    reqwest::get(format!("https://aoe4world.com/api/v0/players/{profile_id}"))
+        .await?
+        .json()
+        .await
+        .map_err(anyhow::Error::from)
 }
 
 /// Get games for a player. Games returned as an async stream.
@@ -59,7 +56,7 @@ pub async fn games(
     since: Option<chrono::DateTime<chrono::Utc>>,
 ) -> Result<impl Stream<Item = Result<Game>>> {
     let client = PaginationClient::<GamesPlayed, Game>::default();
-    let url = format!("https://aoe4world.com/api/v0/players/{}/games", profile_id).parse()?;
+    let url = format!("https://aoe4world.com/api/v0/players/{profile_id}/games").parse()?;
     let filter = games::Filter {
         leaderboard,
         opponent_profile_id: opponent_id.map(ProfileId::from),
@@ -105,11 +102,11 @@ mod tests {
     #[cfg_attr(not(feature = "test-api"), ignore)]
     #[tokio::test]
     async fn profile_api_smoke() {
-        profile(ONLY_CAMS_ID.into())
+        profile(ONLY_CAMS_ID)
             .await
             .expect("API call should succeed");
 
-        profile(HOUSEDHORSE_ID.into())
+        profile(HOUSEDHORSE_ID)
             .await
             .expect("API call should succeed");
     }
@@ -117,44 +114,44 @@ mod tests {
     #[cfg_attr(not(feature = "test-api"), ignore)]
     #[tokio::test(flavor = "multi_thread")]
     async fn games_api_smoke() {
-        let g: Vec<_> = games(ONLY_CAMS_ID.into(), None, None, None)
+        let g: Vec<_> = games(ONLY_CAMS_ID, None, None, None)
             .await
             .expect("API call should succeed")
             .collect()
             .await;
         for (i, game) in g.iter().enumerate() {
-            assert!(game.is_ok(), "game {} not ok: {:?}", i, game)
+            assert!(game.is_ok(), "game {i} not ok: {game:?}")
         }
 
-        let g: Vec<_> = games(HOUSEDHORSE_ID.into(), None, None, None)
+        let g: Vec<_> = games(HOUSEDHORSE_ID, None, None, None)
             .await
             .expect("API call should succeed")
             .collect()
             .await;
         for (i, game) in g.iter().enumerate() {
-            assert!(game.is_ok(), "game {} not ok: {:?}", i, game)
+            assert!(game.is_ok(), "game {i} not ok: {game:?}")
         }
     }
 
     #[cfg_attr(not(feature = "test-api"), ignore)]
     #[tokio::test(flavor = "multi_thread")]
     async fn search_api_smoke() {
-        let profiles: Vec<_> = search(ONLY_CAMS_NAME.into(), true)
+        let profiles: Vec<_> = search(ONLY_CAMS_NAME, true)
             .await
             .expect("API call should succeed")
             .collect()
             .await;
         for (i, profile) in profiles.iter().enumerate() {
-            assert!(profile.is_ok(), "profile {} not ok: {:?}", i, profile)
+            assert!(profile.is_ok(), "profile {i} not ok: {profile:?}")
         }
 
-        let profiles: Vec<_> = search(DEBILS_NAME.into(), false)
+        let profiles: Vec<_> = search(DEBILS_NAME, false)
             .await
             .expect("API call should succeed")
             .collect()
             .await;
         for (i, profile) in profiles.iter().enumerate() {
-            assert!(profile.is_ok(), "profile {} not ok: {:?}", i, profile)
+            assert!(profile.is_ok(), "profile {i} not ok: {profile:?}")
         }
     }
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -24,7 +24,7 @@ pub mod arbitrary_with {
     pub fn url(u: &mut arbitrary::Unstructured) -> arbitrary::Result<url::Url> {
         let s = String::arbitrary(u)?;
         let s: String = s.chars().filter(|c| c.is_alphanumeric()).collect();
-        url::Url::parse(&format!("https://www.example.com/{}", s))
+        url::Url::parse(&format!("https://www.example.com/{s}"))
             .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 
@@ -41,9 +41,9 @@ pub mod arbitrary_with {
     ) -> impl Fn(&mut arbitrary::Unstructured) -> arbitrary::Result<Option<f64>> {
         move |u: &mut arbitrary::Unstructured| -> arbitrary::Result<Option<f64>> {
             let steps = u32::MAX;
-            let factor = (max - min) as f64 / (steps as f64);
+            let factor = (max - min) / (steps as f64);
             let random_int: u32 = u.int_in_range(0..=steps)?;
-            let random = min as f64 + factor * (random_int as f64);
+            let random = min + factor * (random_int as f64);
             Ok(Some(random))
         }
     }

--- a/src/types/profile.rs
+++ b/src/types/profile.rs
@@ -2,10 +2,7 @@
 
 //! API response types for player and profile stats.
 
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-};
+use std::{collections::HashMap, fmt::Display, ops::Deref};
 
 use anyhow::Result;
 use futures::Stream;
@@ -20,17 +17,15 @@ use crate::{games, profile, types::rank::RankLeague, Game, Leaderboard};
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct ProfileId(u64);
 
-impl Deref for ProfileId {
-    type Target = u64;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl Display for ProfileId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
-impl DerefMut for ProfileId {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl AsRef<u64> for ProfileId {
+    fn as_ref(&self) -> &u64 {
+        &self.0
     }
 }
 
@@ -49,7 +44,7 @@ impl From<ProfileId> for u64 {
 impl ProfileId {
     /// Get the profile for this ProfileId.
     pub async fn profile(&self) -> Result<Profile> {
-        profile(**self).await
+        profile(self.0).await
     }
 
     /// Get games for this ProfileId. Games are returned as an async stream.
@@ -65,7 +60,7 @@ impl ProfileId {
         opponent_id: Option<u64>,
         since: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<impl Stream<Item = Result<Game>>> {
-        games(**self, leaderboard, opponent_id, since).await
+        games(self.0, leaderboard, opponent_id, since).await
     }
 }
 

--- a/src/types/rank.rs
+++ b/src/types/rank.rs
@@ -38,12 +38,12 @@ impl<'de> Deserialize<'de> for RankLeague {
         // Split league and division strings at the _ character
         let (league, division) = s
             .split_once('_')
-            .ok_or_else(|| de::Error::custom(format!("invalid rank string: {}", s)))?;
+            .ok_or_else(|| de::Error::custom(format!("invalid rank string: {s}")))?;
 
         // Parse division as an integer and map it onto a ranked division
         let division = division
             .parse::<u32>()
-            .map_err(|e| de::Error::custom(format!("unable to parse division: {}", e)))?;
+            .map_err(|e| de::Error::custom(format!("unable to parse division: {e}")))?;
         let division = RankDivision::try_from(division).map_err(de::Error::custom)?;
 
         // Parse league
@@ -56,8 +56,7 @@ impl<'de> Deserialize<'de> for RankLeague {
             "conqueror" => Self::Conqueror(division),
             _ => {
                 return Err(de::Error::custom(format!(
-                    "invalid league string: {}",
-                    league
+                    "invalid league string: {league}"
                 )))
             }
         };


### PR DESCRIPTION
Exposing profile_id as a u64 had the unintended side effect of expoising a bunch of u64 methods that might confuse a consumer of the API. Let's remove the deref and instead implement the display trait directly.

Signed-off-by: William Findlay <will@isovalent.com>